### PR TITLE
Removed unnecessary image usage in example

### DIFF
--- a/examples/game_of_life/game_of_life.rs
+++ b/examples/game_of_life/game_of_life.rs
@@ -72,7 +72,6 @@ impl GameOfLifeComputePipeline {
             ImageUsage {
                 sampled: true,
                 storage: true,
-                color_attachment: true,
                 transfer_dst: true,
                 ..ImageUsage::none()
             },


### PR DESCRIPTION
Example runs fine without it. The usage combination caused a black screen on my computer.